### PR TITLE
fixed OAuth2's scope delimiter.

### DIFF
--- a/lib/OAuth2/Client.pm
+++ b/lib/OAuth2/Client.pm
@@ -49,7 +49,7 @@ sub authorize_uri {
     my $authorize_uri = "$self->{auth_uri}?client_id=$self->{client_id}&redirect_uri=$self->{redirect_uri}&response_type=$response_type";
     if ($self->{auth_doc}) {
         my @scopes = keys %{$self->{auth_doc}{oauth2}{scopes}};
-        $authorize_uri .= '&scope=' . join ',', @scopes;
+        $authorize_uri .= '&scope=' . join ' ', @scopes;
     }
     return $authorize_uri;
 }
@@ -63,7 +63,7 @@ sub exchange {
         return unless $self->{$key};
     }
     my @scopes = keys %{$self->{auth_doc}{oauth2}{scopes}};
-    my $scopes = join ',', @scopes;
+    my $scopes = join ' ', @scopes;
     my @param = (
         client_id => $self->{client_id},
         client_secret => $self->{client_secret},


### PR DESCRIPTION
$auth_driver->authorize_uri doesn't work when I use Google calendar api (v3) via this client library.

Google calendar api (v3) has TWO SCOPES for OAuth2.
See http://code.google.com/intl/ja/apis/accounts/docs/OAuth2Login.html#formingtheurl .
OAuth2 scope parameter is space-delimited string. It's not comma-delimited.

I fixed it.

Sorry, I didn't write tests.
