### PR TITLE
Escape OAuth's authorization URI properly

### DIFF
--- a/lib/OAuth2/Client.pm
+++ b/lib/OAuth2/Client.pm
@@ -2,7 +2,7 @@ package OAuth2::Client;
 
 use strict;
 use warnings;
-
+use URI;
 
 sub new {
     my $class = shift;
@@ -51,7 +51,7 @@ sub authorize_uri {
         my @scopes = keys %{$self->{auth_doc}{oauth2}{scopes}};
         $authorize_uri .= '&scope=' . join ',', @scopes;
     }
-    return $authorize_uri;
+    return URI->new($authorize_uri)->as_string;
 }
 
 sub exchange {


### PR DESCRIPTION
Hi. Shouldn't the authorization URI be URI::Escape'd?

It seems to work unescaped in the tests, but [this example ](http://code.google.com/intl/pt-BR/apis/accounts/docs/OAuth2Login.html#simpleexample) shows it escaped.

Thanks.
