### PR TITLE
Fixed codes, on GET we need to delete {opt}{body}{foobar}, and added Google Calendar API sample code.

### DIFF
--- a/eg/calendar/list_events.pl
+++ b/eg/calendar/list_events.pl
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use feature qw/say/;
+
+use FindBin;
+use Google::API::Client;
+use OAuth2::Client;
+use URI::Escape;
+use Encode;
+
+use lib 'eg/lib';
+use Sample::Utils qw/get_or_restore_token store_token/;
+
+use constant MAX_LIST_CALENDAR => 3;
+use constant MAX_LIST_EVENTS   => 3;
+
+
+my $client = Google::API::Client->new;
+my $service = $client->build('calendar', 'v3');
+
+my $file = "$FindBin::Bin/../client_secrets.json";
+my $auth_driver = OAuth2::Client->new_from_client_secrets($file, $service->{auth_doc});
+
+my $dat_file = "$FindBin::Bin/token.dat";
+my $access_token = get_or_restore_token($dat_file, $auth_driver);
+
+# Call calendar list 
+my $calendars = $service->calendarList->list(
+    body => {
+        maxResults => MAX_LIST_CALENDAR
+    })->execute({ auth_driver => $auth_driver });
+for my $calendar (@{$calendars->{items}}) {
+    say "== Calendar $calendar->{id} ==";
+    my $calendar_id = uri_escape($calendar->{id});
+    # Call events.list
+    my $events = $service->events->list(body => {
+        calendarId => $calendar_id,
+        maxResults => MAX_LIST_EVENTS,
+        showDeleted => 'true',
+    })->execute({ auth_driver => $auth_driver });
+    for my $event (@{$events->{items}}) {
+        say "== Event $event->{id} ==";
+        my $event_title = defined($event->{summary}) ? encode('utf8', $event->{summary}) : 'N/A';
+        my $event_start = defined($event->{start}) ?
+                         (defined($event->{start}->{date}) ? $event->{start}->{date} :
+                         (defined($event->{start}->{dateTime}) ? $event->{start}->{dateTime} : 'N/A')
+                          ) : 'N/A';
+        my $event_end   = defined($event->{end}) ?
+                         (defined($event->{end}->{date}) ? $event->{end}->{date} :
+                         (defined($event->{end}->{dateTime}) ? $event->{end}->{dateTime} : 'N/A')
+                          ) : 'N/A';
+        my $event_status = $event->{status};
+        say <<EOF;
+event_title  : $event_title
+event_status : $event->{status}
+event_start  : $event_start
+event_end    : $event_end
+EOF
+    }
+    say "";
+}
+
+store_token($dat_file, $auth_driver);
+
+say 'Done';
+__END__

--- a/lib/Google/API/Method.pm
+++ b/lib/Google/API/Method.pm
@@ -20,7 +20,11 @@ sub execute {
     my $self = shift;
     my ($arg) = @_;
     my $url = $self->{base_url} . $self->{doc}{path};
+    my $url_org = $url;
     $url =~ s/{([^}]+)}/$self->{opt}{body}{$1}/g;
+    while ( $url_org =~ /{([^}]+)}/g ) {
+        delete( $self->{opt}{body}{$1} );
+    }
     my $http_method = uc($self->{doc}{httpMethod});
     my $request;
     if ($http_method eq 'POST' ||


### PR DESCRIPTION
We get wrong url like this "http://GOOG_API_URL/{calendarId}/events?calendarId={calendarId}".

Added sample code for Google Calendar API v3.

Google Calendar APIを利用する際、GETを使うのですが、bodyに設定されている"calendarId"が、そのままHTTP queryとして後付けになってしまいます。以下が例です。このURLにアクセスすると403エラーが返ってきます。

GET https://www.googleapis.com/calendar/v3/calendars/{calendarId}/events?calendarId={calendarId}

{opt}{body}{xxx}が複数ある場合も同様なため、正規表現で書き換えた物は全てbodyから消した上で、GET句の処理に入るよう変更しました。

また、調査中に作成したサンプルコードを修正してAddしました。

以上、よろしくお願いします。
