### PR TITLE
allow no redirect_uri to support cross-client exchange request

### DIFF
--- a/lib/Google/API/OAuth2/Client.pm
+++ b/lib/Google/API/OAuth2/Client.pm
@@ -7,7 +7,7 @@ use URI;
 sub new {
     my $class = shift;
     my ($param) = @_;
-    for my $key (qw/auth_uri token_uri client_id client_secret redirect_uri/) {
+    for my $key (qw/auth_uri token_uri client_id client_secret/) {
         return unless $param->{$key};
     }
     unless (defined $param->{ua}) {
@@ -65,7 +65,7 @@ sub exchange {
     my ($code) = @_;
     return unless $code;
     return unless $self->{auth_doc};
-    for my $key (qw/client_id client_secret redirect_uri/) {
+    for my $key (qw/client_id client_secret/) {
         return unless $self->{$key};
     }
     my @scopes = keys %{$self->{auth_doc}{oauth2}{scopes}};


### PR DESCRIPTION
Google supports cross client authorization. See Cross-client access tokens section in https://developers.google.com/accounts/docs/CrossClientAuth. For example, if a user has an Android App with native Google+ login button, the app can sent a request for one-time-code that can be exchanged by a web app with different client id. This is very useful when there is a need to consume existing web services by a mobile applications. In that case the web app must submit the exchange request without any redirect_uri (“When the web component exchanges the code for tokens, it should not include the redirect_uri argument in the POST request.”).
To support this feature the validation in Client.pm should be adjusted.
