### PR TITLE
No automatic removal of params from the body

### DIFF
--- a/lib/Google/API/Method.pm
+++ b/lib/Google/API/Method.pm
@@ -24,9 +24,6 @@ sub execute {
     my %required_param;
     for my $p (@{$self->{doc}{parameterOrder}}) {
         $required_param{$p} = delete $self->{opt}{$p};
-        if ($self->{opt}{body} && $self->{opt}{body}{$p}) {
-            $required_param{$p} = delete $self->{opt}{body}{$p};
-        }
     }
     $url =~ s/{([^}]+)}/uri_escape(delete $required_param{$1})/eg;
     my $uri = URI->new($url);


### PR DESCRIPTION
There are some cases of Google API calls where
a parameter is both required in the URL but also
required in the body.  Removal of the parameter from
the body made these API calls impossible with this library.
