### PR TITLE
Fix content_length(0) problem for requests

### DIFF
--- a/lib/Google/API/Method.pm
+++ b/lib/Google/API/Method.pm
@@ -37,7 +37,9 @@ sub execute {
         $http_method eq 'DELETE') {
         $uri->query_form(\%required_param);
         $request = HTTP::Request->new($http_method => $uri);
-        if ($self->{opt}{body}) {
+        # Some API's (ie: admin/directoryv1/groups/delete) require requests 
+        # with an empty body section to be explicitly zero length.
+        if (%{$self->{opt}{body}}) {
             $request->content_type('application/json');
             $request->content($self->{json_parser}->encode($self->{opt}{body}));
         } else {


### PR DESCRIPTION
Code will submit Content-type: application/json even when there are no values in the $self->{opt}{body} hash.

This breaks the group delete command here: https://developers.google.com/admin-sdk/directory/v1/reference/groups/delete, which requires no body to be sent, and returns a 400 error if something is sent.