### PR TITLE
use URI::Template to Level 2 RFC 6570 URI Template parameters.

### DIFF
--- a/META.json
+++ b/META.json
@@ -42,7 +42,8 @@
             "JSON::WebToken" : "0",
             "LWP::Protocol::https" : "0",
             "URI" : "0",
-            "URI::Escape" : "0"
+           "URI::Escape" : "0",
+           "URI::Template" : "0"
          }
       },
       "test" : {
@@ -77,4 +78,3 @@
       "shigeta <shigeta@typhoon.(none)>"
    ]
 }
-

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'URI';
 requires 'URI::Escape';
+requires 'URI::Template';
 requires 'HTTP::Request';
 requires 'JSON';
 requires 'JSON::WebToken';


### PR DESCRIPTION
Some API discovery documents (like Cloud Pub/Sub API) use level 2 url parameters like

"list": {
   "id": "pubsub.projects.topics.list",
   "path": "v1/{+project}/topics",
   "httpMethod": "GET",
...

The {+project} parameter above implies "Reserved Expansion". To support it and other
more complex URI parameters use the URI::Template per module.

Additionally, was getting an error when a body was not supplied in a request that
did not need a body, so check for that case.