### PR TITLE
Fix example URL shortener code

### DIFF
--- a/lib/Google/API/Client.pm
+++ b/lib/Google/API/Client.pm
@@ -115,6 +115,7 @@ Google::API::Client - A client for Google APIs Discovery Service
 
   my $client = Google::API::Client->new;
   my $service = $client->build('urlshortener', 'v1');
+  my $url = $service->url;
 
   # Get shortened URL 
   my $body = {


### PR DESCRIPTION
The code in SYNOPSIS is broken. url() was never being called on the service.

There *is* still a problem with this example though. It looks like Google no longer allowed unauthenticated requests. I get a "quota exceeded" error when trying to run it.

They allow authentication through either OAuth or using API key. OAuth works fine.
With an API key, I don't see how to append it to the request URL. insert() is a POST method, but they expect you to append the key as a a query string (?key=<KEY>)

I see there's specific code to handle the key parameter for a GET request, but I don't see any way to pass query parameters for non-GET requests.
