### PR TITLE
Allow for requests to Google Analytics Core Reporting v4 API

### DIFF
--- a/lib/Google/API/Client.pm
+++ b/lib/Google/API/Client.pm
@@ -31,6 +31,10 @@ sub build {
     $discovery_service_url =~ s/{api}/$service/;
     $discovery_service_url =~ s/{apiVersion}/$version/;
 
+    if (($service eq 'analyticsreporting') && ($version eq 'v4')) {
+        $discovery_service_url = 'https://analyticsreporting.googleapis.com/$discovery/rest';
+    }
+
     my $req = HTTP::Request->new(GET => $discovery_service_url);
     my $res = $self->{ua}->request($req);
     unless ($res->is_success) {


### PR DESCRIPTION
The standard service discovery URL doesn't work with Google's new Analytics Reporting API, as per https://developers.google.com/analytics/devguides/reporting/core/v4/migration#client_libraries_and_discovery_service.

This fix is perhaps a little basic but does work when sending requests to the new API service.