### PR TITLE
Update discovery template

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Google::API::Client
 
 {{$NEXT}}
+        - Fix Discovery URL template (Thanks, 7mho7 and robhammond)
 
 0.14  2014-10-18 03:08:30 PDT
         - allow no redirect_uri to support cross-client exchange request #14 (Thanks, razsh)

--- a/eg/searchconsole/webmasters_sites_list.pl
+++ b/eg/searchconsole/webmasters_sites_list.pl
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use feature qw/say/;
+
+use FindBin;
+use Google::API::Client;
+use Google::API::OAuth2::Client;
+
+use lib 'eg/lib';
+use Sample::Utils qw/get_or_restore_token store_token/;
+
+
+my $client = Google::API::Client->new;
+
+# https://developers.google.com/search/blog/2020/12/search-console-api-updates#api-library-changes
+# my $service = $client->build('webmasters', 'v3');
+my $service = $client->build('searchconsole', 'v1');
+
+my $file = "$FindBin::Bin/../client_secrets.json";
+my $auth_driver = Google::API::OAuth2::Client->new_from_client_secrets($file, $service->{auth_doc});
+
+my $dat_file = "$FindBin::Bin/token.dat";
+my $access_token = get_or_restore_token($dat_file, $auth_driver);
+
+# Call webmasters.sites.list
+my $res = $service->sites->list->execute({ auth_driver => $auth_driver });
+
+my %sites;
+for my $site (@{$res->{siteEntry}}) {
+    $sites{$site->{siteUrl}} = $site->{permissionLevel};
+}
+for my $url (sort keys %sites) {
+    say $sites{$url} . "\t" . $url;
+}
+
+store_token($dat_file, $auth_driver);
+
+__END__

--- a/lib/Google/API/Client.pm
+++ b/lib/Google/API/Client.pm
@@ -32,6 +32,9 @@ sub build {
         $discovery_service_url .= '?version={apiVersion}';
     }
 
+    if ($self->_is_v1_discovery_url($service, $version)) {
+        $discovery_service_url = 'https://www.googleapis.com/discovery/v1/apis/{api}/{apiVersion}/rest';
+    }
     $discovery_service_url =~ s/{api}/$service/;
     $discovery_service_url =~ s/{apiVersion}/$version/;
 
@@ -100,6 +103,20 @@ sub _new_json_parser {
     require JSON;
     my $parser = JSON->new;
     return $parser;
+}
+
+sub _is_v1_discovery_url {
+    my ($self, $service, $version) = @_;
+    # Following services are still using V1 type URL
+    if (($service eq 'compute' && $version eq 'alpha') ||
+        ($service eq 'compute' && $version eq 'beta') ||
+        ($service eq 'compute' && $version eq 'v1') ||
+        ($service eq 'drive' && $version eq 'v2') ||
+        ($service eq 'drive' && $version eq 'v3') ||
+        ($service eq 'oauth2' && $version eq 'v2')) {
+        return 1;
+    }
+    return;
 }
 
 1;

--- a/lib/Google/API/Client.pm
+++ b/lib/Google/API/Client.pm
@@ -32,6 +32,8 @@ sub build {
         $discovery_service_url .= '?version={apiVersion}';
     }
 
+    $service = $self->_replace_to_subdomain($service);
+
     if ($self->_is_v1_discovery_url($service, $version)) {
         $discovery_service_url = 'https://www.googleapis.com/discovery/v1/apis/{api}/{apiVersion}/rest';
     }
@@ -103,6 +105,24 @@ sub _new_json_parser {
     require JSON;
     my $parser = JSON->new;
     return $parser;
+}
+
+sub _replace_to_subdomain {
+    my ($self, $service) = @_;
+
+    # Following services are different from subdomains.
+    # It needs to be converted.
+    my %replacement = (
+        'adexchangebuyer2'  => 'adexchangebuyer',
+        'calendar'          => 'calendar-json',
+        'content'           => 'shoppingcontent',
+        'prod_tt_sasportal' => 'prod-tt-sasportal',
+        'translate'         => 'translation',
+    );
+    if (grep { $service eq $_ } keys %replacement) {
+        $service = $replacement{$service};
+    }
+    return $service;
 }
 
 sub _is_v1_discovery_url {

--- a/lib/Google/API/Client.pm
+++ b/lib/Google/API/Client.pm
@@ -47,6 +47,7 @@ sub build {
 
     my $req = HTTP::Request->new(GET => $discovery_service_url);
     my $res = $self->{ua}->request($req);
+    $self->{ua}{response} = $res;
     unless ($res->is_success) {
         # throw an error
         die 'could not get service document.' . $res->status_line;

--- a/lib/Google/API/Client.pm
+++ b/lib/Google/API/Client.pm
@@ -27,15 +27,20 @@ sub build {
     my $self = shift;
     my ($service, $version, $args) = @_;
 
-    my $discovery_service_url = 'https://{api}.googleapis.com/$discovery/rest';
-    if ($version) {
-        $discovery_service_url .= '?version={apiVersion}';
-    }
+    my $discovery_service_url;
+    if ($args->{discovery_service_url}) {
+        $discovery_service_url = $args->{discovery_service_url};
+    } else {
+        $discovery_service_url = 'https://{api}.googleapis.com/$discovery/rest';
+        if ($version) {
+            $discovery_service_url .= '?version={apiVersion}';
+        }
 
-    $service = $self->_replace_to_subdomain($service);
+        $service = $self->_replace_to_subdomain($service);
 
-    if ($self->_is_v1_discovery_url($service, $version)) {
-        $discovery_service_url = 'https://www.googleapis.com/discovery/v1/apis/{api}/{apiVersion}/rest';
+        if ($self->_is_v1_discovery_url($service, $version)) {
+            $discovery_service_url = 'https://www.googleapis.com/discovery/v1/apis/{api}/{apiVersion}/rest';
+        }
     }
     $discovery_service_url =~ s/{api}/$service/;
     $discovery_service_url =~ s/{apiVersion}/$version/;

--- a/lib/Google/API/Client.pm
+++ b/lib/Google/API/Client.pm
@@ -27,7 +27,11 @@ sub build {
     my $self = shift;
     my ($service, $version, $args) = @_;
 
-    my $discovery_service_url = 'https://www.googleapis.com/discovery/v1/apis/{api}/{apiVersion}/rest';
+    my $discovery_service_url = 'https://{api}.googleapis.com/$discovery/rest';
+    if ($version) {
+        $discovery_service_url .= '?version={apiVersion}';
+    }
+
     $discovery_service_url =~ s/{api}/$service/;
     $discovery_service_url =~ s/{apiVersion}/$version/;
 

--- a/t/build.t
+++ b/t/build.t
@@ -3,7 +3,7 @@ use Test::More;
 
 use Google::API::Client;
 
-my $service = Google::API::Client->new->build('plus', 'v1');
+my $service = Google::API::Client->new->build('calendar', 'v3');
 ok($service);
 is(ref(Google::API::Client->_new_ua), 'LWP::UserAgent');
 is(ref(Google::API::Client->_new_json_parser), 'JSON');

--- a/t/discovery_url.t
+++ b/t/discovery_url.t
@@ -1,0 +1,67 @@
+use strict;
+use Test::More;
+
+use Google::API::Client;
+
+my $client = Google::API::Client->new;
+
+subtest 'discovery url v2 style' => sub {
+    my $service = $client->build('gmail', 'v1');
+    is($client->{ua}{response}->request->uri, 'https://gmail.googleapis.com/$discovery/rest?version=v1');
+
+    $service = $client->build('analyticsreporting', 'v4');
+    is($client->{ua}{response}->request->uri, 'https://analyticsreporting.googleapis.com/$discovery/rest?version=v4');
+
+    $service = $client->build('searchconsole', 'v1');
+    is($client->{ua}{response}->request->uri, 'https://searchconsole.googleapis.com/$discovery/rest?version=v1');
+};
+
+subtest 'without version' => sub {
+    my $service = $client->build('calendar');
+    is($client->{ua}{response}->request->uri, 'https://calendar-json.googleapis.com/$discovery/rest');
+};
+
+subtest 'backward compatibility' => sub {
+    my $service = $client->build('compute', 'alpha');
+    is($client->{ua}{response}->request->uri, 'https://www.googleapis.com/discovery/v1/apis/compute/alpha/rest');
+
+    $service = $client->build('compute', 'beta');
+    is($client->{ua}{response}->request->uri, 'https://www.googleapis.com/discovery/v1/apis/compute/beta/rest');
+
+    $service = $client->build('compute', 'v1');
+    is($client->{ua}{response}->request->uri, 'https://www.googleapis.com/discovery/v1/apis/compute/v1/rest');
+
+    $service = $client->build('drive', 'v2');
+    is($client->{ua}{response}->request->uri, 'https://www.googleapis.com/discovery/v1/apis/drive/v2/rest');
+
+    $service = $client->build('drive', 'v3');
+    is($client->{ua}{response}->request->uri, 'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest');
+
+    $service = $client->build('oauth2', 'v2');
+    is($client->{ua}{response}->request->uri, 'https://www.googleapis.com/discovery/v1/apis/oauth2/v2/rest');
+
+};
+
+subtest 'convert name to sub domain' => sub {
+    my $service = $client->build('adexchangebuyer2', 'v2beta1');
+    is($client->{ua}{response}->request->uri, 'https://adexchangebuyer.googleapis.com/$discovery/rest?version=v2beta1');
+
+    $service = $client->build('calendar', 'v3');
+    is($client->{ua}{response}->request->uri, 'https://calendar-json.googleapis.com/$discovery/rest?version=v3');
+
+    $service = $client->build('content', 'v2.1');
+    is($client->{ua}{response}->request->uri, 'https://shoppingcontent.googleapis.com/$discovery/rest?version=v2.1');
+
+    $service = $client->build('prod_tt_sasportal', 'v1alpha1');
+    is($client->{ua}{response}->request->uri, 'https://prod-tt-sasportal.googleapis.com/$discovery/rest?version=v1alpha1');
+
+    $service = $client->build('translate', 'v3');
+    is($client->{ua}{response}->request->uri, 'https://translation.googleapis.com/$discovery/rest?version=v3');
+};
+
+subtest 'custom discovery url' => sub {
+    my $service = $client->build('webmaster', 'v3', { discovery_service_url => 'https://searchconsole.googleapis.com/$discovery/rest' });
+    is($client->{ua}{response}->request->uri, 'https://searchconsole.googleapis.com/$discovery/rest');
+};
+
+done_testing;


### PR DESCRIPTION
This PR includes following updates.
- Change discovery URL
- Add discovery_service_url option to Google::API::Client::build method

And I will create a new PR for bumping version soon. Then I will upload new version.

## Change discovery URL

By this change, this module uses new discovery URL

- Previous `https://www.googleapis.com/discovery/v1/apis/{api}/{apiVersion}/rest`
- Current `https://{api}.googleapis.com/$discovery/rest?version={apiVersion}`

Some APIs are still using previous URL though, it is converted by detecting services in `Google::API::Client::_is_v1_discovery_url`.

## discovery_service_url option

You can specify discovery URL by using discovery_service_url option like below. (Following code does not work. Because the discovery URL is dummy.)

```perl
my $client = Google::API::Client->new;
my $service = $client->build('youtube', 'v3', {discovery_service_url = 'https://www.example.com/rest/'});
```

## Other

- Add tests
- Add searchconsole example

## Thanks

Thanks to @robhammond and @7mho7. Their PRs, #26 and #27, helped me to create this PR.